### PR TITLE
feat: direct link from room id to join room page

### DIFF
--- a/pages/rooms/list.tsx
+++ b/pages/rooms/list.tsx
@@ -70,6 +70,9 @@ export default function Home() {
                 {
                   header: 'UUID',
                   property: 'id',
+                  render: (datum: Data) => (
+                    <a href={`/rooms/${datum.id}`}>{datum.id}</a>
+                  ),
                 },
                 {
                   header: 'Max participants',


### PR DESCRIPTION
This PR will add the ability to directly go to the room from /rooms/list by clicking the UUID.

<img width="1678" alt="Screen Shot 2021-11-09 at 20 34 06" src="https://user-images.githubusercontent.com/16728775/140916958-afa69f6b-3655-442d-ad62-ddd4998ecce5.png">
