### PR TITLE
fix: add bounds property to block Chat Box to be out of the view port when is dragging the component

### DIFF
--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -70,7 +70,7 @@ export const Chat = ({
   };
 
   return (
-    <Draggable>
+    <Draggable bounds="body">
       <Wrapper>
         <div
           style={{


### PR DESCRIPTION
 - add bounds property to block Chat Box to be out of the viewport when is dragging the component


Before:
![image](https://user-images.githubusercontent.com/16343871/154995139-f5cf84f1-13c5-4ce4-a169-5a7eb0e495c1.png)


After:
![image](https://user-images.githubusercontent.com/16343871/154995207-ebbf7234-854d-47e9-946b-06269fb5fd7e.png)

