### PR TITLE
chore: disable rules that checks key in jsx files it was not working using typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   plugins: ['react'],
   rules: {
     'react/react-in-jsx-scope': 'off',
+    'react/jsx-key': 'off',
     'no-unused-vars': 'warn',
   },
 };


### PR DESCRIPTION
- disable rules that check key in jsx files it was not working using typescript

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md#when-not-to-use-it
https://github.com/yannickcr/eslint-plugin-react/issues/320


Issue:

You can see that does not make sense the error

![image](https://user-images.githubusercontent.com/16343871/155722714-d974d8ac-7063-4cba-89c2-80981b8edff0.png)
