### PR TITLE
fix: only drag the chatbox when selecting chat header  this way you will be able to copy the text content from chat

### DIFF
--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -69,9 +69,10 @@ export const Chat = ({
   };
 
   return (
-    <Draggable bounds='body'>
+    <Draggable bounds='body' handle="#chat-header">
       <Wrapper>
         <div
+          id="chat-header"
           style={{
             backgroundColor: '#b5a4a4',
             display: 'flex',
@@ -79,6 +80,7 @@ export const Chat = ({
             borderTopRightRadius: 4,
             justifyContent: 'space-between',
             alignItems: 'center',
+            cursor: 'grab'
           }}
         >
           <button


### PR DESCRIPTION
- only drag the chatbox when selecting chat header  this way you will be able to copy the text content from chat

Before: Can't select the text content

![image](https://user-images.githubusercontent.com/16343871/156370270-1aa6289c-ddcb-475d-ad95-fe32757e849a.png)


After: Selecting the text content

![image](https://user-images.githubusercontent.com/16343871/156370165-7cd4ed97-1bad-4d9f-995c-6560544e3494.png)
