### PR TITLE
chore: Add a Dockerfile and generate docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM node:14.17.1-buster
+
+RUN apt-get update \
+    && apt-get install -y \
+    wget \
+    build-essential \
+    pkg-config \
+    libglib2.0-dev \
+    libexpat1-dev \
+    libc6-dev \
+    chromium \
+    yarn
+
+RUN wget https://github.com/libvips/libvips/releases/download/v8.11.0/vips-8.11.0.tar.gz \
+    && tar xf vips-8.11.0.tar.gz \
+    && cd vips-8.11.0 \ 
+    && ./configure
+
+RUN cd vips-8.11.0 \
+    && make \
+    && make install
+
+COPY . /app/telnyx-meet
+
+WORKDIR /app/telnyx-meet
+
+RUN yarn
+
+RUN yarn build
+
+EXPOSE 3000
+
+ENV PROXY_DOMAIN=video.telnyx.com
+CMD ["yarn","dev"]

--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ You can deploy this app with [Vercel](https://vercel.com) ([Documentation](https
 To deploy your local project to Vercel, push it to GitHub/GitLab/Bitbucket and [import to Vercel](https://vercel.com/new).
 
 **Important**: When you import your project on Vercel, make sure to click on **Environment Variables** and set them to match your `.env.local` file.
+
+## **Deploy using docker-compose**
+
+To deploy your local project to a docker container for development purposes, run `docker-compose up -d` from within the telnyx-meet directory.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  web:
+    build: .
+    ports:
+     - "3000:3000"


### PR DESCRIPTION
The video-meet repo has a Dockerfile which hasn't been worked on since 2021 and used some deprecated yarn commands. This commit updates the Dockerfile and adds a docker-compose.yml to allow a simpler Docker development environment. 