### PR TITLE
[WEBRTC-1578] Microphone source resets to the default option after muting/unmuting

### DIFF
--- a/components/MediaPreview/MediaControlBar.tsx
+++ b/components/MediaPreview/MediaControlBar.tsx
@@ -26,7 +26,6 @@ const FontAwesomeIcon = styled(BaseFontAwesomeIcon)`
 `;
 
 function MediaControlBar({
-  setAudioInputDeviceId,
   audioInputDeviceId,
   setVideoInputDeviceId,
   videoInputDeviceId,
@@ -44,7 +43,6 @@ function MediaControlBar({
       video: MediaStreamTrack | undefined;
     }>
   >;
-  setAudioInputDeviceId: Dispatch<SetStateAction<string | undefined>>;
   audioInputDeviceId: string | undefined;
   setVideoInputDeviceId: Dispatch<SetStateAction<string | undefined>>;
   videoInputDeviceId: string | undefined;
@@ -56,7 +54,6 @@ function MediaControlBar({
     if (localTracks?.audio) {
       localTracks.audio.stop();
       setLocalTracks((value) => ({ ...value, audio: undefined }));
-      setAudioInputDeviceId(undefined);
       saveItem(USER_PREFERENCE_AUDIO_ENABLED, 'no');
     } else {
       getUserMedia({
@@ -68,7 +65,6 @@ function MediaControlBar({
             ...value,
             audio: stream?.getAudioTracks()[0],
           }));
-          setAudioInputDeviceId(stream?.getAudioTracks()[0].id);
           saveItem(USER_PREFERENCE_AUDIO_ENABLED, 'yes');
         })
         // TODO: avoid disable line

--- a/components/MediaPreview/MediaControlBar.tsx
+++ b/components/MediaPreview/MediaControlBar.tsx
@@ -27,7 +27,6 @@ const FontAwesomeIcon = styled(BaseFontAwesomeIcon)`
 
 function MediaControlBar({
   audioInputDeviceId,
-  setVideoInputDeviceId,
   videoInputDeviceId,
   setError,
   localTracks,
@@ -44,7 +43,6 @@ function MediaControlBar({
     }>
   >;
   audioInputDeviceId: string | undefined;
-  setVideoInputDeviceId: Dispatch<SetStateAction<string | undefined>>;
   videoInputDeviceId: string | undefined;
   setError: Dispatch<
     SetStateAction<{ title: string; body: string } | undefined>
@@ -79,7 +77,6 @@ function MediaControlBar({
     if (localTracks?.video) {
       localTracks.video.stop();
       setLocalTracks((value) => ({ ...value, video: undefined }));
-      setVideoInputDeviceId(undefined);
       saveItem(USER_PREFERENCE_VIDEO_ENABLED, 'no');
     } else {
       getUserMedia({
@@ -92,7 +89,6 @@ function MediaControlBar({
             video: stream?.getVideoTracks()[0],
           }));
 
-          setVideoInputDeviceId(stream?.getVideoTracks()[0].id);
           saveItem(USER_PREFERENCE_VIDEO_ENABLED, 'yes');
         })
         // TODO: avoid disable line

--- a/components/MediaPreview/index.tsx
+++ b/components/MediaPreview/index.tsx
@@ -41,7 +41,6 @@ function MediaPreview({ error, setError }: { error: any; setError: any }) {
   const {
     audioInputDeviceId,
     videoInputDeviceId,
-    setVideoInputDeviceId,
     localTracks,
     setLocalTracks,
   } = useContext(TelnyxMeetContext);
@@ -123,7 +122,6 @@ function MediaPreview({ error, setError }: { error: any; setError: any }) {
             localTracks={localTracks}
             setLocalTracks={setLocalTracks}
             audioInputDeviceId={audioInputDeviceId}
-            setVideoInputDeviceId={setVideoInputDeviceId}
             videoInputDeviceId={videoInputDeviceId}
             setError={setError}
           />

--- a/components/MediaPreview/index.tsx
+++ b/components/MediaPreview/index.tsx
@@ -40,7 +40,6 @@ const VideoPreview = styled.div`
 function MediaPreview({ error, setError }: { error: any; setError: any }) {
   const {
     audioInputDeviceId,
-    setAudioInputDeviceId,
     videoInputDeviceId,
     setVideoInputDeviceId,
     localTracks,
@@ -123,7 +122,6 @@ function MediaPreview({ error, setError }: { error: any; setError: any }) {
           <MediaControlBar
             localTracks={localTracks}
             setLocalTracks={setLocalTracks}
-            setAudioInputDeviceId={setAudioInputDeviceId}
             audioInputDeviceId={audioInputDeviceId}
             setVideoInputDeviceId={setVideoInputDeviceId}
             videoInputDeviceId={videoInputDeviceId}

--- a/components/Room.tsx
+++ b/components/Room.tsx
@@ -27,7 +27,6 @@ function Room({
 }) {
   const [isParticipantsListVisible, setIsParticipantsListVisible] =
     useState<boolean>(false);
-  const [audioOutputDeviceId, setAudioOutputDeviceId] = useState<string>();
 
   const room = useRoom({
     roomId,
@@ -128,7 +127,6 @@ function Room({
                 ? room.presenter.id !== room.getLocalParticipant().id
                 : false
             }
-            onAudioOutputDeviceChange={setAudioOutputDeviceId}
             sendMessage={room.sendMessage}
             messages={room.messages}
             getLocalParticipant={room.getLocalParticipant}
@@ -138,7 +136,6 @@ function Room({
             participants={state.participants}
             streams={state.streams}
             mixedAudioTrack={state.mixedAudioTrack}
-            audioOutputDeviceId={audioOutputDeviceId}
           />
         </>
       )}

--- a/components/RoomAudio.tsx
+++ b/components/RoomAudio.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 
 import { TelnyxRoom } from 'hooks/room';
+import { TelnyxMeetContext } from 'contexts/TelnyxMeetContext';
 import AudioTrack from 'components/AudioTrack';
 
 export default function RoomAudio({
@@ -8,14 +9,14 @@ export default function RoomAudio({
   streams,
   useAudioMixer,
   mixedAudioTrack,
-  audioOutputDeviceId,
 }: {
   participants: TelnyxRoom['state']['participants'];
   streams: TelnyxRoom['state']['streams'];
   useAudioMixer: boolean;
   mixedAudioTrack?: MediaStreamTrack;
-  audioOutputDeviceId?: MediaDeviceInfo['deviceId'];
 }) {
+  const { audioOutputDeviceId } = useContext(TelnyxMeetContext);
+
   const audioTracks = useMemo(() => {
     if (useAudioMixer) {
       return [];

--- a/components/RoomControls.tsx
+++ b/components/RoomControls.tsx
@@ -457,7 +457,6 @@ export default function RoomControls({
             size='large'
             onClick={() => {
               if (localTracks.video) {
-                setVideoInputDeviceId('');
                 localTracks.video.stop();
                 if (selfStream?.videoTrack) {
                   selfStream?.videoTrack.stop();
@@ -475,7 +474,6 @@ export default function RoomControls({
                       ...value,
                       video: stream?.getVideoTracks()[0],
                     }));
-                    setVideoInputDeviceId(stream?.getVideoTracks()[0].id);
                   })
                   .catch((err) => {
                     handleMediaError(err, 'video');

--- a/components/RoomControls.tsx
+++ b/components/RoomControls.tsx
@@ -137,7 +137,6 @@ export default function RoomControls({
   onChangeParticipantsListVisible,
   streams,
   disableScreenshare,
-  onAudioOutputDeviceChange,
   participantsByActivity,
   addStream,
   removeStream,
@@ -156,9 +155,6 @@ export default function RoomControls({
   onChangeParticipantsListVisible: Function;
   streams: { [key: string]: Stream };
   disableScreenshare: boolean;
-  onAudioOutputDeviceChange: React.Dispatch<
-    React.SetStateAction<string | undefined>
-  >;
   sendMessage: Room['sendMessage'];
   messages: TelnyxRoom['messages'];
   getLocalParticipant: () => Participant;
@@ -358,10 +354,8 @@ export default function RoomControls({
   };
 
   useEffect(() => {
-    onAudioOutputDeviceChange(audioOutputDeviceId);
-    // TODO: avoid disable line
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [audioOutputDeviceId]);
+    setAudioOutputDeviceId(audioOutputDeviceId);
+  }, [audioOutputDeviceId, setAudioOutputDeviceId]);
 
   const removeMediaTracks = () => {
     localTracks?.audio?.stop();

--- a/components/RoomControls.tsx
+++ b/components/RoomControls.tsx
@@ -405,7 +405,6 @@ export default function RoomControls({
                 if (selfStream?.audioTrack) {
                   selfStream?.audioTrack.stop();
                 }
-                setAudioInputDeviceId('');
                 setLocalTracks((value) => ({ ...value, audio: undefined }));
               } else {
                 getUserMedia({
@@ -419,7 +418,6 @@ export default function RoomControls({
                       ...value,
                       audio: stream?.getAudioTracks()[0],
                     }));
-                    setAudioInputDeviceId(stream?.getAudioTracks()[0].id);
                   })
                   .catch((err) => {
                     handleMediaError(err, 'audio');

--- a/pages/rooms/index.tsx
+++ b/pages/rooms/index.tsx
@@ -131,7 +131,6 @@ export default function Rooms({ id }: { id: string }) {
           if (isAudioEnabled === 'yes') {
             const localAudioTrack = stream?.getAudioTracks()[0];
             setLocalTracks((value) => ({ ...value, audio: localAudioTrack }));
-            setAudioInputDeviceId(localAudioTrack.id);
           }
 
           if (isVideoEnabled === 'yes') {

--- a/pages/rooms/index.tsx
+++ b/pages/rooms/index.tsx
@@ -136,7 +136,6 @@ export default function Rooms({ id }: { id: string }) {
           if (isVideoEnabled === 'yes') {
             const localVideoTrack = stream?.getVideoTracks()[0];
             setLocalTracks((value) => ({ ...value, video: localVideoTrack }));
-            setVideoInputDeviceId(localVideoTrack.id);
           }
 
           setError(undefined);


### PR DESCRIPTION
The `audioInputDeviceId`, a value used to get the user-selected device, is reset on audio mute, and it is too changed to [`MediaStreamTrack.id`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/id) on audio unmute.

In each case, it causes the following code to either `getUserMedia` with audio `true` because the `deviceId` is undefined, or to request with a `deviceId` that does not exists because the `MediaStreamTrack.id` is not the same as [`MediaDeviceInfo.deviceId`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDeviceInfo/deviceId) – persisting value used to identify the device.

```js
getUserMedia({
  audio: audioInputDeviceId
    ? { deviceId: audioInputDeviceId }
     : true,
  video: false,
})
```

**Note that the same issue occurs with Camera source.**

This PR will remove any instances where `audioInputDeviceId`, or `videoInputDeviceId` value is reset or changed to `MediaStreamTrack.id`, leaving only the instances where the user sets the preferred device.