### PR TITLE
feat(WEBRTC-1654):  add query parameters client_token and refresh_token to be able to join a room without API authentication

### DIFF
--- a/components/JoinRoom.tsx
+++ b/components/JoinRoom.tsx
@@ -21,6 +21,8 @@ const JoinRoom = ({
   updateRoomId,
   updateUsername,
   updateTokens,
+  clientToken,
+  refreshToken,
 }: Props) => {
   const [error, setError] = useState<
     { title: string; body: string } | undefined
@@ -47,6 +49,14 @@ const JoinRoom = ({
   };
 
   const joinRoom = async () => {
+    if (clientToken && refreshToken) {
+      updateTokens({
+        clientToken,
+        refreshToken,
+      });
+      return;
+    }
+
     const response = await fetch('/api/client_token', {
       method: 'POST',
       body: JSON.stringify({

--- a/pages/rooms/[roomId].tsx
+++ b/pages/rooms/[roomId].tsx
@@ -5,11 +5,19 @@ import Rooms from './';
 
 const RoomId = () => {
   const router = useRouter();
-  const { roomId } = router.query as { roomId: string };
+  const { roomId, client_token, refresh_token } = router.query as {
+    roomId: string;
+    client_token: string;
+    refresh_token: string;
+  };
 
   return (
     <Fragment>
-      <Rooms id={roomId} />
+      <Rooms
+        id={roomId}
+        clientToken={client_token}
+        refreshToken={refresh_token}
+      />
     </Fragment>
   );
 };

--- a/pages/rooms/index.tsx
+++ b/pages/rooms/index.tsx
@@ -44,7 +44,15 @@ function getUserName(): string {
     return generateUsername();
   }
 }
-export default function Rooms({ id }: { id: string }) {
+export default function Rooms({
+  id,
+  clientToken,
+  refreshToken,
+}: {
+  id: string;
+  clientToken: string;
+  refreshToken: string;
+}) {
   const [roomId, setRoomId] = useState<string>();
 
   const [username, setUsername] = useState<string>('');
@@ -197,6 +205,8 @@ export default function Rooms({ id }: { id: string }) {
                 updateUsername={setUsername}
                 updateRoomId={setRoomId}
                 updateTokens={setTokens}
+                clientToken={clientToken}
+                refreshToken={refreshToken}
               />
             </GridPreviewContainer>
           )}


### PR DESCRIPTION
- add query parameters client_token and refresh_token to be able to join a room without API authentication


You can add `client_token` and `refresh_token` in the URL and the application should not call the API to generate them.

![image](https://user-images.githubusercontent.com/16343871/162230052-34bc837d-ba0f-4edb-b63e-e2d4a72e4a5f.png)
