### PR TITLE
feat(WEBRTC-1838): use_mixed_audio query parameter to control output

### DIFF
--- a/components/Room.tsx
+++ b/components/Room.tsx
@@ -207,7 +207,7 @@ function Room({
             getLocalParticipant={room.getLocalParticipant}
           />
           <RoomAudio
-            useAudioMixer={true}
+            useMixedAudioForOutput={optionalFeatures.useMixedAudioForOutput}
             participants={state.participants}
             streams={state.streams}
             mixedAudioTrack={state.mixedAudioTrack}

--- a/components/RoomAudio.tsx
+++ b/components/RoomAudio.tsx
@@ -3,36 +3,37 @@ import React, { useContext, useMemo } from 'react';
 import { TelnyxRoom } from 'hooks/room';
 import { TelnyxMeetContext } from 'contexts/TelnyxMeetContext';
 import AudioTrack from 'components/AudioTrack';
+import { Participant } from '@telnyx/video';
 
 export default function RoomAudio({
   participants,
   streams,
-  useAudioMixer,
+  useMixedAudioForOutput,
   mixedAudioTrack,
 }: {
   participants: TelnyxRoom['state']['participants'];
   streams: TelnyxRoom['state']['streams'];
-  useAudioMixer: boolean;
+  useMixedAudioForOutput: boolean;
   mixedAudioTrack?: MediaStreamTrack;
 }) {
   const { audioOutputDeviceId } = useContext(TelnyxMeetContext);
 
   const audioTracks = useMemo(() => {
-    if (useAudioMixer) {
+    if (useMixedAudioForOutput) {
       return [];
     }
 
     const audioTracks: Array<{ id: string; track: MediaStreamTrack }> = [];
 
-    participants.forEach((participant) => {
+    participants.forEach((participant: Participant) => {
       if (participant.origin === 'local') {
         return;
       }
 
-      const selfStreamId = participant.streams.get('self');
+      const selfStreamId = participant.streams['self'];
       if (selfStreamId) {
         const stream = streams.get(selfStreamId);
-        if (!stream || !stream.transceiver.isConfigured) {
+        if (!stream) {
           return;
         }
 
@@ -46,10 +47,10 @@ export default function RoomAudio({
     });
 
     return audioTracks;
-  }, [streams, participants, useAudioMixer]);
+  }, [streams, participants, useMixedAudioForOutput]);
 
   const roomAudio = useMemo(() => {
-    if (useAudioMixer) {
+    if (useMixedAudioForOutput) {
       if (mixedAudioTrack) {
         return (
           <AudioTrack
@@ -73,7 +74,12 @@ export default function RoomAudio({
         />
       );
     });
-  }, [audioTracks, useAudioMixer, mixedAudioTrack, audioOutputDeviceId]);
+  }, [
+    audioTracks,
+    useMixedAudioForOutput,
+    mixedAudioTrack,
+    audioOutputDeviceId,
+  ]);
 
   return <>{roomAudio}</>;
 }

--- a/pages/rooms/[roomId].tsx
+++ b/pages/rooms/[roomId].tsx
@@ -11,12 +11,15 @@ const RoomId = () => {
     network_metrics: string;
     simulcast: string;
     dial_out: string;
+    use_mixed_audio: string;
   };
 
   const optionalFeatures = {
     isNetworkMetricsEnabled: queryParameters.network_metrics === 'true',
     isSimulcastEnabled: queryParameters.simulcast === 'true',
     isDialOutEnabled: queryParameters.dial_out === 'true',
+    useMixedAudioForOutput:
+      queryParameters.use_mixed_audio === 'false' ? false : true, // by default this is true
   };
 
   return (


### PR DESCRIPTION
Use `?use_mixed_audio=false` to disable mixed audio output. By default it will use mixed audio for output.