### PR TITLE
[WEBRTC-1914] Enable Video Bitrate

### DIFF
--- a/components/Feed.tsx
+++ b/components/Feed.tsx
@@ -20,6 +20,7 @@ import VideoTrack from 'components/VideoTrack';
 import { WebRTCStats } from 'components/WebRTCStats';
 import { TelnyxMeetContext } from 'contexts/TelnyxMeetContext';
 import { NetworkMetricsMonitor } from './NetworkMetricsMonitor';
+import { VideoBitrate } from 'components/VideoBitrate';
 
 const VIDEO_BG_COLOR = '#111';
 
@@ -72,6 +73,24 @@ function Feed({
     setAllowedBrowser(allowed);
   }, []);
 
+  const renderVideoBitrate = () => {
+    if (participant.origin === 'local') {
+      return null;
+    }
+
+    if (!stream || !stream.isConfigured || !allowedBrowser) {
+      return null;
+    }
+
+    return (
+      <VideoBitrate
+        participant={participant}
+        stream={stream}
+        getStatsForParticipantStream={getStatsForParticipantStream}
+      />
+    );
+  };
+
   function resetWebRTCStats() {
     clearInterval(intervalStatsId.current);
     intervalStatsId.current = null;
@@ -80,7 +99,7 @@ function Feed({
   }
 
   function renderStats() {
-    if (!stream || !allowedBrowser) {
+    if (!stream || !stream.isConfigured || !allowedBrowser) {
       return null;
     }
 
@@ -160,12 +179,13 @@ function Feed({
             justifyContent: 'space-between',
           }}
         >
-          {stream?.isConfigured && renderStats()}
+          {renderStats()}
           {!showStatsOverlay && peerMetrics && (
             <NetworkMetricsMonitor
               connectionQuality={peerMetrics.connectionQuality}
             />
           )}
+          {renderVideoBitrate()}
         </div>
       </div>
 

--- a/components/VideoBitrate.tsx
+++ b/components/VideoBitrate.tsx
@@ -54,12 +54,6 @@ function VideoBitrate({
       return;
     }
 
-    if (previousBytesReceived === 0) {
-      setBitrate(8 * currentBytesReceived);
-      setPreviousBytesReceived(currentBytesReceived);
-      return;
-    }
-
     setBitrate(8 * (currentBytesReceived - previousBytesReceived));
     setPreviousBytesReceived(currentBytesReceived);
   }, [previousBytesReceived, currentBytesReceived]);
@@ -76,9 +70,11 @@ function VideoBitrate({
         round='xxsmall'
         width='106px'
       >
-        <Text color='status-disabled' size='xsmall'>Video:</Text>
         <Text color='status-disabled' size='xsmall'>
-          {stream?.isVideoEnabled ? Math.floor(bitrate / 1000) : 0} kbps
+          Video:
+        </Text>
+        <Text color='status-disabled' size='xsmall'>
+          {stream.isVideoEnabled ? Math.floor(bitrate / 1000) : 0} kbps
         </Text>
       </Box>
     </Box>


### PR DESCRIPTION
Now that the issue with `getWebRTCStatsForStream` throwing an error when there's no `avStreamSubscriber` has been solved, this PR will bring back the video bitrate component.