### PR TITLE
feat(WEBRTC-2001): add a new query parameter to enable audio_control button in room controls component

### DIFF
--- a/components/RoomControls.tsx
+++ b/components/RoomControls.tsx
@@ -704,17 +704,19 @@ export default function RoomControls({
       </Box>
 
       <RightBoxMenu pad='small' direction='row' gap='large'>
-        <Box>
-          <Button
-            onClick={() => {
-              setUseMixedAudioForOutput(!useMixedAudioForOutput);
-            }}
-          >
-            <Text>{`Toggle Mixed Audio: ${
-              useMixedAudioForOutput ? 'On' : 'Off'
-            }`}</Text>
-          </Button>
-        </Box>
+        {optionalFeatures && optionalFeatures.isAudioControlEnabled && (
+          <Box>
+            <Button
+              onClick={() => {
+                setUseMixedAudioForOutput(!useMixedAudioForOutput);
+              }}
+            >
+              <Text>{`Toggle Mixed Audio: ${
+                useMixedAudioForOutput ? 'On' : 'Off'
+              }`}</Text>
+            </Button>
+          </Box>
+        )}
 
         <DeviceSelect
           kind='audio_input'

--- a/pages/rooms/index.tsx
+++ b/pages/rooms/index.tsx
@@ -50,11 +50,13 @@ export default function Rooms({
 }) {
   const router = useRouter();
   const queryParameters = router.query as {
+    audio_control: string;
     dial_out: string;
     network_metrics: string;
     simulcast: string;
   };
   const optionalFeatures = {
+    isAudioControlEnabled: queryParameters.audio_control === 'true',
     isDialOutEnabled: queryParameters.dial_out === 'true',
     isNetworkMetricsEnabled: queryParameters.network_metrics === 'true',
     isSimulcastEnabled: queryParameters.simulcast === 'true',


### PR DESCRIPTION
- add a new query parameter to enable audio_control button in room controls component

Audio Control True
![image](https://user-images.githubusercontent.com/16343871/176451571-0b0c0b8b-12ee-43f3-a493-cf38fba00a45.png)

Audio Control False

![image](https://user-images.githubusercontent.com/16343871/176452272-404fbd5d-854f-488d-bbd5-d4b67155ba4c.png)
