### PR TITLE
fix(WEBRTC-2006): check if key exist before set dominant speaker

### DIFF
--- a/hooks/room.ts
+++ b/hooks/room.ts
@@ -325,6 +325,7 @@ export const useRoom = ({
 
         roomRef.current.on('audio_activity', (participantId, key) => {
           if (
+            key &&
             key !== 'presentation' &&
             participantId !== roomRef.current!.getLocalParticipant().id
           ) {


### PR DESCRIPTION
Issue: When we are sharing a tab with audio playing and the publisher is with audio disabled the activity speaker still activated for the publisher

On Video SDK in `participant_register` when emitting `audio_activity` we don't have the key name of the stream and the Telnyx-meet was receiving the `key: null` that is different from `key: 'self'` due to this it was setting the `setDominantSpeakerId` for the participant even though the `self` stream was not talking. 