### PR TITLE
hotfix(WEBRTC-2031):  The virtual background feature only works in desktop chrome 

### DIFF
--- a/components/MediaPreview/MediaControlBar.tsx
+++ b/components/MediaPreview/MediaControlBar.tsx
@@ -36,6 +36,7 @@ import {
   VirtualBackground,
 } from 'utils/virtualBackground';
 import { MenuList } from 'components/MenuList';
+import { getBrowserName } from 'utils/helpers';
 
 const breakpointLarge = 1450;
 
@@ -335,6 +336,7 @@ function MediaControlBar({
       </Button>
       {optionalFeatures &&
         optionalFeatures.isVirtualBackgroundFeatureEnabled &&
+        getBrowserName() === 'chrome' &&
         renderSelectBackgroungImage()}
     </React.Fragment>
   );

--- a/components/MediaPreview/MediaControlBar.tsx
+++ b/components/MediaPreview/MediaControlBar.tsx
@@ -36,7 +36,7 @@ import {
   VirtualBackground,
 } from 'utils/virtualBackground';
 import { MenuList } from 'components/MenuList';
-import { getBrowserName } from 'utils/helpers';
+import { getBrowserName, getPlatform } from 'utils/helpers';
 
 const breakpointLarge = 1450;
 
@@ -337,6 +337,7 @@ function MediaControlBar({
       {optionalFeatures &&
         optionalFeatures.isVirtualBackgroundFeatureEnabled &&
         getBrowserName() === 'chrome' &&
+        getPlatform()?.type === 'desktop' &&
         renderSelectBackgroungImage()}
     </React.Fragment>
   );

--- a/components/RoomControls.tsx
+++ b/components/RoomControls.tsx
@@ -1,10 +1,4 @@
-import {
-  useState,
-  useEffect,
-  useContext,
-  useRef,
-  MutableRefObject,
-} from 'react';
+import { useState, useEffect, useContext, useRef } from 'react';
 import { getDevices, Participant, Room, Stream } from '@telnyx/video';
 import { Box, Button, Menu, Text } from 'grommet';
 import {
@@ -42,6 +36,7 @@ import {
   VirtualBackground,
 } from 'utils/virtualBackground';
 import { MenuList } from './MenuList';
+import { getBrowserName } from 'utils/helpers';
 
 const breakpointMedium = 1023;
 
@@ -869,6 +864,7 @@ export default function RoomControls({
       <RightBoxMenu pad='small' direction='row' gap='large'>
         {optionalFeatures &&
           optionalFeatures.isVirtualBackgroundFeatureEnabled &&
+          getBrowserName() === 'chrome' &&
           renderSelectBackgroungImage()}
         <Box>
           <Button

--- a/components/RoomControls.tsx
+++ b/components/RoomControls.tsx
@@ -36,7 +36,7 @@ import {
   VirtualBackground,
 } from 'utils/virtualBackground';
 import { MenuList } from './MenuList';
-import { getBrowserName } from 'utils/helpers';
+import { getBrowserName, getPlatform } from 'utils/helpers';
 
 const breakpointMedium = 1023;
 
@@ -865,6 +865,7 @@ export default function RoomControls({
         {optionalFeatures &&
           optionalFeatures.isVirtualBackgroundFeatureEnabled &&
           getBrowserName() === 'chrome' &&
+          getPlatform()?.type === 'desktop' &&
           renderSelectBackgroungImage()}
         <Box>
           <Button

--- a/components/VideoTrack.tsx
+++ b/components/VideoTrack.tsx
@@ -1,6 +1,7 @@
 import { Stream } from '@telnyx/video';
 import React, { useRef, useEffect } from 'react';
 import { useState } from 'react';
+import { getBrowserName } from 'utils/helpers';
 import { VirtualBackground } from 'utils/virtualBackground';
 
 export default function VideoTrack({
@@ -39,6 +40,7 @@ export default function VideoTrack({
     if (
       virtualBackgroundCamera &&
       virtualBackgroundCamera.current &&
+      getBrowserName() === 'chrome' &&
       //https://developer.mozilla.org/en-US/docs/Web/API/CanvasCaptureMediaStreamTrack
       //@ts-ignore
       stream.videoTrack instanceof CanvasCaptureMediaStreamTrack

--- a/components/VideoTrack.tsx
+++ b/components/VideoTrack.tsx
@@ -1,7 +1,7 @@
 import { Stream } from '@telnyx/video';
 import React, { useRef, useEffect } from 'react';
 import { useState } from 'react';
-import { getBrowserName } from 'utils/helpers';
+import { getBrowserName, getPlatform } from 'utils/helpers';
 import { VirtualBackground } from 'utils/virtualBackground';
 
 export default function VideoTrack({
@@ -41,6 +41,7 @@ export default function VideoTrack({
       virtualBackgroundCamera &&
       virtualBackgroundCamera.current &&
       getBrowserName() === 'chrome' &&
+      getPlatform()?.type === 'desktop' &&
       //https://developer.mozilla.org/en-US/docs/Web/API/CanvasCaptureMediaStreamTrack
       //@ts-ignore
       stream.videoTrack instanceof CanvasCaptureMediaStreamTrack

--- a/pages/rooms/index.tsx
+++ b/pages/rooms/index.tsx
@@ -11,7 +11,7 @@ import Room from 'components/Room';
 import JoinRoom from 'components/JoinRoom';
 import MediaPreview from 'components/MediaPreview';
 
-import { generateUsername, generateId } from 'utils/helpers';
+import { generateUsername, generateId, getPlatform } from 'utils/helpers';
 import { TelnyxMeetContext } from 'contexts/TelnyxMeetContext';
 
 import { TelnyxRoom } from 'hooks/room';

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -34,3 +34,14 @@ export const getBrowserName = () => {
 
   return browserName;
 };
+
+export const getPlatform = () => {
+  if (!Bowser || !window) {
+    return undefined;
+  }
+
+  const browser = Bowser.getParser(window.navigator.userAgent);
+  const platform = browser.getPlatform();
+
+  return platform;
+};

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,5 +1,6 @@
 import { uniqueNamesGenerator, colors, animals } from 'unique-names-generator';
 import { notify } from 'lib/bugsnag';
+import Bowser from 'bowser';
 
 export const generateId = (): number => Math.ceil(Math.random() * 1000000);
 
@@ -21,4 +22,15 @@ export const transformFetchErrorToBugsnag = (
   } catch (error) {
     notify(`request-id: ${requestId} - ${error}`);
   }
+};
+
+export const getBrowserName = () => {
+  if (!Bowser || !window) {
+    return undefined;
+  }
+
+  const browser = Bowser.getParser(window.navigator.userAgent);
+  const browserName = browser.getBrowserName().toLowerCase();
+
+  return browserName;
 };


### PR DESCRIPTION
 - I tested the new feature in all major browsers and mobile phones and it seems that the official media pipe was only well tested in desktop chrome browsers. To avoid surprises in other browsers I added a check to only allow virtual background in desktop chrome browsers.
 
 [Officia web demo](https://codepen.io/mediapipe/pen/wvJyQpq)
 
 Message:
 
 **All Mobiles**
 
![Screenshot_20220711-114834_Chrome](https://user-images.githubusercontent.com/16343871/178293514-1ffbbf3d-e8ac-462b-ba65-01f7ce99fb1d.jpg)

**Desktop not chrome**

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/16343871/178293677-af4458f6-30e4-4274-beae-9fa1e54fa081.png">



