### PR TITLE
fix(WEBRTC-2116): show audio activity indicator for PSTN participant

### DIFF
--- a/components/Feed/Feed.tsx
+++ b/components/Feed/Feed.tsx
@@ -47,7 +47,9 @@ function Feed({
 }: FeedProps) {
   const isTelephonyEngineParticipant =
     participant.origin === 'telephony_engine';
-  const showAudioActivityIndicator = isSpeaking && stream?.key === 'self';
+  const showAudioActivityIndicator =
+    isSpeaking &&
+    (participant.origin === 'telephony_engine' || stream?.key === 'self');
   const [showStatsOverlay, setShowStatsOverlay] = useState(false);
   const [allowedBrowser, setAllowedBrowser] = useState(false);
 


### PR DESCRIPTION
Fix the Feed component to show audio activity if the participant's origin is `telephony_engine`.