### PR TITLE
refact(WEBRTC-2126): Network Monitor component to be always visible

### DIFF
--- a/components/Feed/Feed.tsx
+++ b/components/Feed/Feed.tsx
@@ -79,19 +79,6 @@ function Feed({
     );
   };
 
-  const renderNetworkMetricsMonitor = () => {
-    if (
-      !stream ||
-      !stream.isConfigured ||
-      !allowedBrowser ||
-      showStatsOverlay
-    ) {
-      return null;
-    }
-
-    return <NetworkMetricsMonitor participant={participant} />;
-  };
-
   const renderVideoBitrate = () => {
     if (participant.origin === 'local') {
       return null;
@@ -130,6 +117,16 @@ function Feed({
       isPresentation={isPresentation}
       showAudioActivityIndicator={showAudioActivityIndicator}
     >
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          zIndex: 3,
+        }}
+      >
+        <NetworkMetricsMonitor participant={participant} />
+      </div>
       <FeedHeader showBlackBackgroundColor={showBlackBackgroundColor}>
         <div
           style={{
@@ -138,11 +135,9 @@ function Feed({
           }}
         >
           {renderStats()}
-          {renderNetworkMetricsMonitor()}
           {renderVideoBitrate()}
         </div>
       </FeedHeader>
-
       <VideoContainer>
         {showSpinner && (
           <FeedSpinner data-testid='spinner-status'>

--- a/components/Feed/Feed.tsx
+++ b/components/Feed/Feed.tsx
@@ -117,7 +117,7 @@ function Feed({
       isPresentation={isPresentation}
       showAudioActivityIndicator={showAudioActivityIndicator}
     >
-      {allowedBrowser && (
+      {allowedBrowser && !showStatsOverlay && (
         <div
           style={{
             position: 'absolute',

--- a/components/Feed/Feed.tsx
+++ b/components/Feed/Feed.tsx
@@ -117,16 +117,19 @@ function Feed({
       isPresentation={isPresentation}
       showAudioActivityIndicator={showAudioActivityIndicator}
     >
-      <div
-        style={{
-          position: 'absolute',
-          top: 0,
-          right: 0,
-          zIndex: 3,
-        }}
-      >
-        <NetworkMetricsMonitor participant={participant} />
-      </div>
+      {allowedBrowser && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            zIndex: 3,
+          }}
+        >
+          <NetworkMetricsMonitor participant={participant} />
+        </div>
+      )}
+
       <FeedHeader showBlackBackgroundColor={showBlackBackgroundColor}>
         <div
           style={{


### PR DESCRIPTION
With the NQ v2 we will need to always show the network connectivity bars because the new implementation will not be based on the WebRTC Stats anymore for the `local participant` and it will be based on the network request delay.